### PR TITLE
Fixes for dependency breaking changes (flutter_bloc and flutter_facebook_login)

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/lib/login/login_bloc.dart
+++ b/lib/login/login_bloc.dart
@@ -49,7 +49,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
   void onLoginFacebook(LoginWidget view) async {
     dispatch(LoginEventInProgress());
     final facebookSignInRepo = FacebookLogin();
-    final signInResult = await facebookSignInRepo.logInWithReadPermissions(["email"]);
+    final signInResult = await facebookSignInRepo.logIn(["email"]);
     if (signInResult.status == FacebookLoginStatus.loggedIn) {
       LoginRepo.getInstance().signInWithFacebook(signInResult);
     } else if (signInResult.status == FacebookLoginStatus.cancelledByUser) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
 
-  flutter_bloc:
+  flutter_bloc: 0.16.0
   firebase_auth:
   firebase_messaging:
   cloud_firestore:


### PR DESCRIPTION
(Temporarily) fixes breaking changes in new versions plugins:
1. flutter_bloc
By pinning version to 0.16.0
2. fluttter_facebook_login
By updating call to logInWithReadPermission() with logIn() in login_bloc.dart

Issue created at https://github.com/nstosic/toptal-flutter-chat/issues/5